### PR TITLE
Fix network retraction bug

### DIFF
--- a/dmpr.py
+++ b/dmpr.py
@@ -806,7 +806,6 @@ in current | in retracted | msg retracted |
         obsolete = []
         for network, current in self.networks['current'].items():
             if current + hold_time < now:
-                self.networks['retracted'][network] = now
                 obsolete.append(network)
 
         if obsolete:


### PR DESCRIPTION
This fixes a critical bug where networks which were just obsolete were
getting added to the retracted list, which propagated the retracted
status through the whole network.