### PR TITLE
Improve speed

### DIFF
--- a/dmpr/dmpr.py
+++ b/dmpr/dmpr.py
@@ -728,7 +728,7 @@ in current | in retracted | msg retracted |
 
         # Add own networks if they changed
         networks = self._prepare_networks()
-        if not self._eq_dicts(base_msg['networks'], networks):
+        if base_msg['networks'] != networks:
             packet['networks'] = networks
 
         # Add all changed paths, on a policy-node basis
@@ -739,8 +739,8 @@ in current | in retracted | msg retracted |
         for policy in self.routing_data:
             base_msg_policy = base_routing_data.get(policy, {})
             for node, node_data in self.routing_data[policy].items():
-                if node not in base_msg_policy or not self._eq_dicts(
-                        base_msg_policy[node], node_data):
+                if node not in base_msg_policy or \
+                                base_msg_policy[node] != node_data:
                     path = node_data['path']
                     path.apply_attributes(link_attributes)
                     routing_data.setdefault(policy, {})[node] = {
@@ -870,25 +870,3 @@ in current | in retracted | msg retracted |
 
     def _dummy_cb(self, *args, **kwargs):
         pass
-
-    @classmethod
-    def _eq_dicts(cls, dict1, dict2):
-        return dict1 == dict2
-        if dict1 is None or dict2 is None:
-            return False
-
-        if not isinstance(dict1, dict) or not isinstance(dict2, dict):
-            return False
-
-        if set(dict1.keys()) != set(dict2.keys()):
-            return False
-
-        for key, value in dict1.items():
-            if isinstance(value, dict):
-                if not cls._eq_dicts(dict1[key], dict2[key]):
-                    return False
-            else:
-                if dict1[key] != dict2[key]:
-                    return False
-
-        return True

--- a/dmpr/dmpr.py
+++ b/dmpr/dmpr.py
@@ -8,7 +8,7 @@ from .config import DefaultConfiguration
 from .exceptions import ConfigurationException, InvalidPartialUpdate, \
     InvalidMessage
 from .message import Message
-from .path import Path
+from .path import Path, LinkAttributes
 from .policies import AbstractPolicy
 
 
@@ -444,7 +444,7 @@ class DMPR(object):
         """
         interface = self._conf['interfaces'][interface_name]
         path = Path(path=neighbor,
-                    attributes={},
+                    attributes=LinkAttributes(),
                     next_hop=neighbor,
                     next_hop_interface=interface_name)
 
@@ -661,7 +661,7 @@ in current | in retracted | msg retracted |
         if self.routing_data:
             routing_data = {}
             node_data = {}
-            link_attributes = {}
+            link_attributes = LinkAttributes()
 
             # We need to separate the routing data for the new base message
             # because we need to be able to compare two entries, which is
@@ -732,7 +732,7 @@ in current | in retracted | msg retracted |
             packet['networks'] = networks
 
         # Add all changed paths, on a policy-node basis
-        link_attributes = {}
+        link_attributes = LinkAttributes()
         routing_data = {}
         base_routing_data = base_msg.get('routing-data', {})
         # Check for new or updated routes

--- a/dmpr/path.py
+++ b/dmpr/path.py
@@ -16,18 +16,8 @@ class Path(object):
         if len(path) % 2 != 1:
             raise InternalException("Invalid path: {}".format(path))
 
-        self.links = []
-        self.nodes = []
-        for i, element in enumerate(path):
-            if i % 2 == 0:
-                # This is a node
-                self.nodes.append(element)
-            else:
-                # This is a link
-                if not (element.startswith('[') and element.endswith(']')):
-                    msg = "Invalid path: {}, link format error: {}"
-                    raise InternalException(msg.format(path, element))
-                self.links.append(element.strip('[]'))
+        self.links = [i.strip('[]') for i in path[1::2]]
+        self.nodes = [i for i in path[::2]]
 
         self.attributes = attributes
         self.next_hop = next_hop

--- a/dmpr/path.py
+++ b/dmpr/path.py
@@ -5,12 +5,38 @@ def dict_reverse_lookup(d: dict, value):
     return list(d.keys())[list(d.values()).index(value)]
 
 
+class LinkAttributes(dict):
+    """
+    This class is here mainly for caching reasons
+    """
+
+    def __init__(self, attributes=None):
+        if attributes is None:
+            attributes = {}
+        super(LinkAttributes, self).__init__(attributes)
+        self.current_id = int(max(attributes, key=int, default=0))
+
+    def get_next_id(self):
+        self.current_id += 1
+        return str(self.current_id)
+
+
 class Path(object):
     """
     Auxiliary class to handle paths, appending and their link attributes
     """
 
-    def __init__(self, path: str, attributes: dict,
+    __slots__ = (
+        'links',
+        'nodes',
+        'attributes',
+        'next_hop',
+        'next_hop_interface',
+        '_global_attributes',
+        'policy_cache',
+    )
+
+    def __init__(self, path: str, attributes: LinkAttributes,
                  next_hop: str, next_hop_interface: str):
         path = path.split('>')
         if len(path) % 2 != 1:
@@ -25,10 +51,6 @@ class Path(object):
         self._global_attributes = {}
         self.policy_cache = {}
 
-    @staticmethod
-    def _next_id(attributes: dict) -> str:
-        return str(int(max(attributes, key=int, default=0)) + 1)
-
     def append(self, node: str, new_next_hop_interface: str, attributes: dict):
         """
         Append a node with link attributes to the front of the path
@@ -36,21 +58,20 @@ class Path(object):
         self.next_hop_interface = new_next_hop_interface
         self.next_hop = self.nodes[0]
 
-        attribute_id = self._next_id(self.attributes)
+        attribute_id = self.attributes.get_next_id()
         self.links.insert(0, attribute_id)
         self.nodes.insert(0, node)
         self.attributes[attribute_id] = attributes
         self.policy_cache = {}
 
-    def apply_attributes(self, attributes: dict):
+    def apply_attributes(self, attributes: LinkAttributes):
         """
         Append all necessary attributes to the global attributes dictionary
         """
         for link in self.links:
             attr = self.attributes[link]
             if attr not in attributes.values():
-                attribute_id = self._next_id(attributes)
-                attributes[attribute_id] = attr
+                attributes[attributes.get_next_id()] = attr
 
         self._global_attributes = attributes
 

--- a/test_dmpr.py
+++ b/test_dmpr.py
@@ -1,56 +1,6 @@
-from .dmpr import DMPR
+from dmpr import DMPR
 
-from .dmpr.path import Path, LinkAttributes
-
-
-class TestAuxMethods:
-    @staticmethod
-    def get_dict():
-        return {
-            1: {1: 1, 2: 2},
-            2: {1: 1, 2: 2},
-            3: {1: (1, 2)},
-            4: "test",
-            5: [2, 3]
-        }
-
-    def test_cmp_dict_simple(self):
-        f = DMPR._eq_dicts
-
-        assert not f(None, None)
-        assert f({}, {})
-        assert f({1: 1}, {1: 1})
-        assert not f({1: 1}, {2: 1})
-        assert not f({1: 1}, {1: 2})
-
-        assert f({1: {1: 1}}, {1: {1: 1}})
-        assert not f({1: {1: 1}}, {1: {1: 2}})
-        assert not f({1: {1: 1}}, {1: {2: 1}})
-
-    def test_cmp_dict_deep(self):
-        f = DMPR._eq_dicts
-        dict1 = self.get_dict()
-        dict2 = self.get_dict()
-
-        assert f(dict1, dict1)
-        assert f(dict1, dict2)
-        dict2[3][1] = (1, 2)
-        assert f(dict1, dict2)
-        dict2[3][1] = (2, 3)
-        assert not f(dict1, dict2)
-
-    def test_cmp_dict_deep_mutable(self):
-        f = DMPR._eq_dicts
-        dict1 = self.get_dict()
-        dict2 = self.get_dict()
-
-        dict1[5] = [self.get_dict()]
-        dict2[5] = [self.get_dict()]
-        assert f(dict1, dict2)
-        dict2[5][0][4] = "error"
-        assert not f(dict1, dict2)
-        dict2[5][0] = None
-        assert not f(dict1, dict2)
+from dmpr.path import Path, LinkAttributes
 
 
 class TestPath:

--- a/test_dmpr.py
+++ b/test_dmpr.py
@@ -1,4 +1,6 @@
-from dmpr import DMPR, Path
+from .dmpr import DMPR
+
+from .dmpr.path import Path, LinkAttributes
 
 
 class TestAuxMethods:
@@ -52,12 +54,13 @@ class TestAuxMethods:
 
 
 class TestPath:
-    def get_path(self):
+    @staticmethod
+    def get_path():
         return Path(path='A>[1]>B>[2]>C',
-                    attributes={
+                    attributes=LinkAttributes({
                         '1': {'loss': 10},
                         '2': {'loss': 20}
-                    },
+                    }),
                     next_hop='B',
                     next_hop_interface='wlan0')
 
@@ -76,14 +79,14 @@ class TestPath:
 
     def test_correct_applying_to_new(self):
         path = self.get_path()
-        attributes = {}
+        attributes = LinkAttributes()
         path.apply_attributes(attributes)
         assert {'loss': 20} in attributes.values()
         assert {'loss': 10} in attributes.values()
 
     def test_correct_applying_to_others(self):
         path = self.get_path()
-        attributes = {'1': {'loss': 30}}
+        attributes = LinkAttributes({'1': {'loss': 30}})
         path.apply_attributes(attributes)
         assert {'loss': 20} in attributes.values()
         assert {'loss': 10} in attributes.values()
@@ -91,7 +94,7 @@ class TestPath:
 
     def test_str(self):
         path = self.get_path()
-        attributes = {}
+        attributes = LinkAttributes()
         path.apply_attributes(attributes)
 
         expected = "A>[{}]>B>[{}]>C"


### PR DESCRIPTION
All paths in a message share the same link-attributes, therefore we should share them between the path-objects too to save memory and computation time