### PR TITLE
Switch to python logging infrastructure

### DIFF
--- a/dmpr/__init__.py
+++ b/dmpr/__init__.py
@@ -1,2 +1,2 @@
 from .policies import SimpleLossPolicy, SimpleBandwidthPolicy
-from .dmpr import DMPR, NoOpTracer, NoOpLogger
+from .dmpr import DMPR, NoOpTracer


### PR DESCRIPTION
The reorganized dmpr-simulator uses the python logging stuff, so we should switch to it in the core, too