### PR TITLE
Widmann/feat dynamic update

### DIFF
--- a/dmpr/dmpr.py
+++ b/dmpr/dmpr.py
@@ -171,12 +171,13 @@ class DMPR(object):
         :param json_data: JSON formattet string containing the data from api
         :return: ---
         """
+        interface = json_data['peer']['interface']
         for destination in json_data['destinations']:
             dest_attr = {'bandwidth': destination['max_datarate_tx']}
-            for interface in self.msg_db: # todo interface from api?
-                for neighbor, msg in self.msg_db[interface].items():
-                    if destination['ipv4-address'] == msg.addr_v4:
-                        self._conf['interfaces'][interface]['neighbor-attributes'][neighbor] = dest_attr
+            for neighbor, msg in self.msg_db[interface].items():
+                if destination['ipv4-address'] == msg.addr_v4:
+                    self._conf['interfaces'][interface]['neighbor-attributes'][neighbor] = dest_attr
+                    self.state.update_required = True
 
     ##################
     #  dmpr rx path  #
@@ -874,7 +875,7 @@ in current | in retracted | msg retracted |
              ]
              }
         """
-        print("->>>>>>>>>>>>> {}".format(self.routing_table))
+        # print("->>>>>>>>>>>>> {}".format(self.routing_table))
         self._routing_table_update_func(self.routing_table)
 
     ###########

--- a/dmpr/dmpr.py
+++ b/dmpr/dmpr.py
@@ -206,7 +206,7 @@ class DMPR(object):
                 for neighbor, msg in self.msg_db[interface].items():
                     if msg.addr_v4 == event['ipv4-addr']:
                         to_remove.append(neighbor)
-                    else if 'ipv6-addr' in event:
+                    elif 'ipv6-addr' in event:
                         if msg.addr_v6 == event['ipv6-addr']:
                             to_remove.append(neighbor)
 
@@ -255,7 +255,7 @@ class DMPR(object):
                 if message.addr_v4 in interface['neighbor-attributes']['unknown']:
                     interface['neighbor-attributes'][msg['id']] = interface['neighbor-attributes'][
                         'unknown'][message.addr_v4]
-                else if message.addr_v6 in interface['neighbor-attributes']['unknown']:
+                elif message.addr_v6 in interface['neighbor-attributes']['unknown']:
                     interface['neighbor-attributes'][msg['id']] = interface['neighbor-attributes'][
                             'unknown'][message.addr_v6]
 

--- a/dmpr/dmpr.py
+++ b/dmpr/dmpr.py
@@ -48,6 +48,8 @@ class DMPRState(object):
         self.full_only_mode = False
 
 
+
+
 class DMPR(object):
     """
     The core class. Before starting the core, you must register a configuration
@@ -168,7 +170,7 @@ class DMPR(object):
         """
         method for handling the dynamic update.
         The inforamtion is provided by the REST-api as json String
-        :param json_data: JSON formattet string containing the data from api
+        :param json_data: JSON formatted string containing the data from api
         :return: ---
         """
         interface = json_data['peer']['interface']
@@ -186,6 +188,18 @@ class DMPR(object):
             if not neighbor_known:
                 self._conf['interfaces'][interface]['neighbor-attributes']['unknown']['{}'.format(
                     destination['ipv4-address'])] = dest_attr
+
+        # TODO: this was never tested
+        for event in json_data['events']:
+            if event['event-type'] == 'dest-down':
+                to_remove = []
+                for neighbor, msg in self.msg_db[interface].items():
+                    if msg.addr_v4 == event['ipv4-addr']:
+                        to_remove.append(neighbor)
+                for rem_neighbor in to_remove:
+                    del self.msg_db[interface][rem_neighbor]
+
+
 
     ##################
     #  dmpr rx path  #

--- a/dmpr/dmpr.py
+++ b/dmpr/dmpr.py
@@ -173,7 +173,9 @@ class DMPR(object):
         """
         interface = json_data['peer']['interface']
         for destination in json_data['destinations']:
-            dest_attr = {'bandwidth': destination['max_datarate_tx']}
+            dest_attr = {'bandwidth': destination['max_datarate_tx'],
+                         # TODO: NO, loss is NOT latency!!!
+                         'loss': destination['latency']}
             for neighbor, msg in self.msg_db[interface].items():
                 if destination['ipv4-address'] == msg.addr_v4:
                     self._conf['interfaces'][interface]['neighbor-attributes'][neighbor] = dest_attr
@@ -875,7 +877,7 @@ in current | in retracted | msg retracted |
              ]
              }
         """
-        # print("->>>>>>>>>>>>> {}".format(self.routing_table))
+        print("->>>>>>>>>>>>> {}".format(self.routing_table))
         self._routing_table_update_func(self.routing_table)
 
     ###########

--- a/dmpr/dmpr.py
+++ b/dmpr/dmpr.py
@@ -802,12 +802,12 @@ in current | in retracted | msg retracted |
         """
         Set the next transmit time
         """
-        interval = self._conf["rtn-msg-interval"]
+        interval = int(self._conf["rtn-msg-interval"])
         if self.state.next_tx_time is None:
             # first time transmitting, just wait jitter to join network faster
             interval = 0
 
-        jitter = self._conf["rtn-msg-interval-jitter"]
+        jitter = int(self._conf["rtn-msg-interval-jitter"])
         wait_time = interval + random.random() * jitter
         now = self.now()
         self.state.next_tx_time = now + wait_time

--- a/dmpr/dmpr.py
+++ b/dmpr/dmpr.py
@@ -15,12 +15,6 @@ from .policies import AbstractPolicy
 
 logger = logging.getLogger(__name__)
 
-mylog = logging.getLogger("mylog")
-fh = logging.FileHandler('/var/logs/tmp/myLog.txt')
-formatter = logging.Formatter('{"time": "%(asctime)s", "log": %(message)s}')
-fh.setFormatter(formatter)
-mylog.addHandler(fh)
-
 FULL_MODE_ANALYSE_HISTORY = 10
 FULL_MODE_TRIGGER_THRESH = 100
 FULL_MODE_TIME = 1000
@@ -218,7 +212,6 @@ class DMPR(object):
                     logmsg = dict()
                     logmsg['event'] = 'update-interval'
                     logmsg['msg'] = self.id
-                    mylog.error(logmsg)
 
     ##################
     #  dmpr rx path  #
@@ -229,8 +222,6 @@ class DMPR(object):
         receive routing packet, save it in the message
         database and trigger all recalculations
         """
-
-        print("rx {}".format(msg['id']))
         self.trace('rx.msg', msg)
 
         if interface_name not in self._conf['interfaces']:
@@ -655,7 +646,6 @@ in current | in retracted | msg retracted |
             logmsg = dict()
             logmsg['event'] = 'tx-packet'
             logmsg['msg'] = msg
-            mylog.error(logmsg)
             self.trace('tx.msg', msg)
 
             for v in (4, 6):
@@ -940,7 +930,6 @@ in current | in retracted | msg retracted |
                'id': self.id,
                'msg': self.routing_table,
                'num-hosts': len(direct_neighbors)}
-        mylog.error(msg)
         self._routing_table_update_func(self.routing_table)
 
     ###########

--- a/dmpr/path.py
+++ b/dmpr/path.py
@@ -125,3 +125,5 @@ class Path(object):
                 return False
 
         return True
+
+    __repr__ = __str__

--- a/dmpr/policies.py
+++ b/dmpr/policies.py
@@ -68,4 +68,4 @@ class SimpleBandwidthPolicy(AbstractPolicy):
     def path_cmp_key(self, path: Path) -> float:
         # the minimum bandwidth of the path while slightly preferring
         # shorter paths
-        return - self._acc_bw(path) * 0.99 ** len(path.links)
+        return - self._acc_bw(path) * (0.99 ** len(path.links))


### PR DESCRIPTION
DMPR is now able to handle dynamic link updates. The dynamic updates are received by rest-api.
The information can be provided for example by any Radio-to-Router communication protocols (e.g. DLEP).

The new feature is tested in mininet simulation environment as well as on real hardware